### PR TITLE
Remove custom __hash__ crashes pickle.load

### DIFF
--- a/jip/maven.py
+++ b/jip/maven.py
@@ -67,6 +67,12 @@ class Artifact(object):
     def __repr__(self):
         return self.__str__()
 
+    def __hash__(self):
+        if hasattr(self, 'group') and hasattr(self, 'artifact') and hasattr(self, 'version'):
+            return self.group.__hash__()*13+self.artifact.__hash__()*7+self.version.__hash__()
+        else:
+            return 0
+
     def is_snapshot(self):
         return self.version.find('SNAPSHOT') > 0
 

--- a/jip/maven.py
+++ b/jip/maven.py
@@ -67,9 +67,6 @@ class Artifact(object):
     def __repr__(self):
         return self.__str__()
 
-    def __hash__(self):
-        return self.group.__hash__()*13+self.artifact.__hash__()*7+self.version.__hash__()
-
     def is_snapshot(self):
         return self.version.find('SNAPSHOT') > 0
 

--- a/jip/maven.py
+++ b/jip/maven.py
@@ -68,6 +68,9 @@ class Artifact(object):
         return self.__str__()
 
     def __hash__(self):
+        ## python3 set requires a custom hash function to ensure item hash unchanged
+        ## however, python2 pickle module might call this function before internal
+        ## propertoes loaded. So here we return 0 if no key property loaded as a workaround
         if hasattr(self, 'group') and hasattr(self, 'artifact') and hasattr(self, 'version'):
             return self.group.__hash__()*13+self.artifact.__hash__()*7+self.version.__hash__()
         else:


### PR DESCRIPTION
Fixes #34 

This issue is caused by an update of python pickle module that it tries to call `__hash__` before properties loaded. So here we just remove the custom `__hash__` definition.

@wikier PTAL
