### PR TITLE
Bugfix/jip cache virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-build
-dist
+build/
+dist/
+env/
 MANIFEST
 *.class
 *.pyc
 *.swp
 *~
-jip.egg-info
+jip.egg-info/

--- a/README.rst
+++ b/README.rst
@@ -318,13 +318,24 @@ Contact
 
 If you have any problem using jip, or feature request for jip,
 please feel free to fire an issue on
-`github issue tracker <http://github.com/sunng87/jip/issues/>`_. You can
+`github issue tracker <http://github.com/jiptool/jip/issues/>`_. You can
 also follow `@Sunng <http://twitter.com/Sunng/>`_ on twitter.
 
 Change Notes
 ------------
 
-### 0.9.8 (2016-07-27)
+Next version - unreleased
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Fix .jip/cache not being isolated in virtualenv
+
+0.9.9 (2016-10-31)
+~~~~~~~~~~~~~~~~~~
+
+- Fix possible crash
+
+0.9.8 (2016-07-27)
+~~~~~~~~~~~~~~~~~~
 
 - Minor fixes
 

--- a/jip/cache.py
+++ b/jip/cache.py
@@ -21,6 +21,7 @@
 #
 
 from jip.repository import MavenRepos
+from jip.util import get_virtual_home
 
 import os
 import shutil
@@ -28,7 +29,8 @@ import shutil
 class CacheRepository(MavenRepos):
     def __init__(self):
         self.name = 'cache'
-        self.uri = os.path.expanduser(os.path.join('~', '.jip', 'cache'))
+        self.uri = os.path.expanduser(os.path.join(get_virtual_home(),
+                                      '.jip', 'cache'))
         if not os.path.exists(self.uri):
             os.makedirs(self.uri)
 


### PR DESCRIPTION
.jip/cache has always been stored in $HOME no matter if I'm in virtualenv or not.