### PR TITLE
Use bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,6 +4,8 @@ commit = True
 tag = True
 tag_name = {new_version}
 
+[bumpversion:file:setup.py]
+
 [bumpversion:file:jip/__init__.py]
 serialize = {major}, {minor}, {patch}
 parse = (?P<major>\d+), (?P<minor>\d+), (?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,15 @@
+[bumpversion]
+current_version = 0.9.11
+commit = True
+tag = True
+tag_name = {new_version}
+
+[bumpversion:file:jip/__init__.py]
+serialize = {major}, {minor}, {patch}
+parse = (?P<major>\d+), (?P<minor>\d+), (?P<patch>\d+)
+
+[bumpversion:file:README.rst]
+search = - Next version - unreleased
+replace = - Next version - unreleased
+	- {new_version} - {now:%Y-%m-%d}
+

--- a/README.rst
+++ b/README.rst
@@ -326,6 +326,8 @@ Change Notes
 
 - Next version - unreleased
 
+  - Remove jip.JIP_VERSION. Use jip.__version__ if you need it.
+
 - 0.9.11 - 2017-03-09
 
   - Improve handling of download errors

--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ Change Notes
 
   - Remove jip.JIP_VERSION. Use jip.__version__ if you need it.
 
-- 0.9.11 - 2017-03-09
+- 0.9.11 - 2017-03-11
 
   - Improve handling of download errors
 

--- a/README.rst
+++ b/README.rst
@@ -324,81 +324,76 @@ also follow `@Sunng <http://twitter.com/Sunng/>`_ on twitter.
 Change Notes
 ------------
 
-0.9.11 (2017-03-11)
-~~~~~~~~~~~~~~~~~~~~~~~~~
+- Next version - unreleased
 
-- Improve handling of download errors
+- 0.9.11 - 2017-03-09
 
-0.9.10 (2017-03-09)
-~~~~~~~~~~~~~~~~~~~
+  - Improve handling of download errors
 
-- Fix .jip/cache not being isolated in virtualenv
+- 0.9.10 - 2017-03-09
 
-0.9.9 (2016-10-31)
-~~~~~~~~~~~~~~~~~~
+  - Fix .jip/cache not being isolated in virtualenv
 
-- Fix possible crash
+- 0.9.9 - 2016-10-31
 
-0.9.8 (2016-07-27)
-~~~~~~~~~~~~~~~~~~
+  - Fix possible crash
 
-- Minor fixes
+- 0.9.8 - 2016-07-27
 
-0.9 (2015-04-23)
-~~~~~~~~~~~~~~~~
+  - Minor fixes
 
-- Python 3 support
+- 0.9 - 2015-04-23
 
-0.8 (2014-03-31)
-~~~~~~~~~~~~~~~~
+  - Python 3 support
 
-- Windows support
+- 0.8 - 2014-03-31
 
-0.7 (2011-06-11)
-~~~~~~~~~~~~~~~~
+  - Windows support
 
-- All new jip.embed and global installation
-- enhanced search
-- dry-run option for ``install``, ``deps`` and ``resolve``
-- exclusion for ``install`` command and jip.dist
-- local maven repository is disabled by default
-- improved dependency resolving speed
-- jip now maintains a local cache of jars and poms in ``$HOME/.jip/cache/``
-- use argparse for better command-line ui
-- add some test cases
+- 0.7 - 2011-06-11
 
-0.5.1 (2011-05-14)
-~~~~~~~~~~~~~~~~~~
+  - All new jip.embed and global installation
+  - enhanced search
+  - dry-run option for ``install``, ``deps`` and ``resolve``
+  - exclusion for ``install`` command and jip.dist
+  - local maven repository is disabled by default
+  - improved dependency resolving speed
+  - jip now maintains a local cache of jars and poms in
+    ``$HOME/.jip/cache/``
+  - use argparse for better command-line ui
+  - add some test cases
 
-- Artifact jar package download in paralell
-- User-agent header included in http request
-- new command `freeze` to dump current state
-- bugfix
+- 0.5.1 - 2011-05-14
 
-0.4 (2011-04-15)
-~~~~~~~~~~~~~~~~
+  - Artifact jar package download in paralell
+  - User-agent header included in http request
+  - new command `freeze` to dump current state
+  - bugfix
 
-- New commands available: ``search``, ``deps``, ``list``, ``remove``
-- New feature ``jip.dist`` for setuptools integration
-- Dependency exclusion support, thanks *vvangelovski*
-- Allow project-scoped repository defined in ``pom.xml`` and ``setup.py``
-- Code refactoring, now programming friendly
-- README converted to reStructuredText
-- Migrate to MIT License
+- 0.4 - 2011-04-15
 
-0.2.1 (2011-04-07)
-~~~~~~~~~~~~~~~~~~
+  - New commands available: ``search``, ``deps``, ``list``, ``remove``
+  - New feature ``jip.dist`` for setuptools integration
+  - Dependency exclusion support, thanks *vvangelovski*
+  - Allow project-scoped repository defined in ``pom.xml`` and
+    ``setup.py``
+  - Code refactoring, now programming friendly
+  - README converted to reStructuredText
+  - Migrate to MIT License
 
-- Improved console output format
-- Correct scope dependency management inheritance
-- Alpha release of snapshot management, you can update a snapshot artifact
-- Environment independent configuration. ``.jip`` for each environment
-- Bug fixes
+- 0.2.1 - 2011-04-07
 
-0.1 (2011-01-04)
-~~~~~~~~~~~~~~~~
+  - Improved console output format
+  - Correct scope dependency management inheritance
+  - Alpha release of snapshot management, you can update a snapshot
+    artifact
+  - Environment independent configuration. ``.jip`` for each
+    environment
+  - Bug fixes
 
-- Initial release
+- 0.1 - 2011-01-04
+
+  - Initial release
 
 Links
 -----

--- a/jip/__init__.py
+++ b/jip/__init__.py
@@ -23,7 +23,6 @@
 __author__ = 'Sun Ning <classicning@gmail.com>'
 __version_info__ = (0, 9, 11)
 __version__ = ".".join(str(i) for i in __version_info__)
-JIP_VERSION = __version__
 __license__ = 'MIT'
 import logging
 logging.basicConfig(level=logging.INFO, format="\033[1m%(name)s\033[0m %(message)s")

--- a/jip/__init__.py
+++ b/jip/__init__.py
@@ -20,9 +20,10 @@
 # SOFTWARE.
 #
 
-JIP_VERSION = '0.9.11'
 __author__ = 'Sun Ning <classicning@gmail.com>'
-__version__ = JIP_VERSION
+__version_info__ = (0, 9, 11)
+__version__ = ".".join(str(i) for i in __version_info__)
+JIP_VERSION = __version__
 __license__ = 'MIT'
 import logging
 logging.basicConfig(level=logging.INFO, format="\033[1m%(name)s\033[0m %(message)s")

--- a/jip/commands.py
+++ b/jip/commands.py
@@ -29,7 +29,7 @@ import inspect
 from string import Template
 
 from jip import repos_manager, index_manager, logger,\
-        JIP_VERSION, __path__, pool, cache_manager
+        __version__, __path__, pool, cache_manager
 from jip.maven import Pom, Artifact
 from jip.util import get_lib_path, get_virtual_home
 
@@ -232,7 +232,7 @@ def update(artifact_id):
 @command()
 def version():
     """ Display jip version """
-    logger.info('[Version] jip %s, jython %s' % (JIP_VERSION, sys.version))
+    logger.info('[Version] jip %s, jython %s' % (__version__, sys.version))
 
 @command(options=[
     ("dry-run", 0, "perform a command without actual download", bool)

--- a/jip/util.py
+++ b/jip/util.py
@@ -34,9 +34,9 @@ except ImportError:
     import Queue as queue
 import threading
 
-from jip import JIP_VERSION, logger
+from jip import __version__, logger
 
-JIP_USER_AGENT = 'jip/%s' % JIP_VERSION
+JIP_USER_AGENT = 'jip/%s' % __version__
 BUF_SIZE = 4096
 
 class DownloadException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from jip import JIP_VERSION as version
-
 long_description = open('README.rst').read()
 
 def is_virtualenv():
@@ -36,7 +34,7 @@ def is_virtualenv():
 
 setup_args=dict(
         name="jip",
-        version=version,
+        version="0.9.11",
         author="Sun Ning",
         author_email="classicning@gmail.com",
         url="https://github.com/sunng87/jip",


### PR DESCRIPTION
This PR makes it possible to just call `bumpversion patch` (or `bumpversion minor`, `bumpversion major`) to update versions, the changelog section of the README and add tags. As a last step `git push --tags` is required to have a new release.
This would drop support for `.devX` versions. It might be possible with bumpversion. I haven't checked as I don't see a need for that.

@jiptool what do you think?