### PR TITLE
Travis CI: Upgrade beyond Python 3.4 because it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,25 @@
 language: python
-sudo: false
-python:
-- '2.6'
-- '2.7'
-- '3.4'
-- '3.5'
 matrix:
   include:
-  - python: 2.7
+  - python: '2.6'
+  - python: '2.7'
+    before_script:
+      - pip install flake8
+      - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  - python: '3.5'
+  - python: '3.6'
+  - python: '3.7'
+    dist: xenial  # required for Python >= 3.7
+    before_script:
+      - pip install flake8
+      - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  - python: '2.7'
     env: JYTHON=org.python:jython-installer:2.7.0
 before_install:
 - if [ -n "$JYTHON" ]; then ./ci/before_install_jython.sh; source $HOME/myvirtualenv/bin/activate
   ;fi
 install:
-- if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install unittest2; fi
 - pip install -e .
 script:
 - python test/testsuite.py

--- a/jip/repository.py
+++ b/jip/repository.py
@@ -29,6 +29,7 @@ import os
 import locale
 import shutil
 import stat
+import sys
 import time
 import hashlib
 try:
@@ -287,7 +288,7 @@ class MavenHttpRemoteRepos(MavenRepos):
             hasher = hashlib.sha1()
 
         buf_size = 1024*8
-        file_to_check = file(filepath, 'r')
+        file_to_check = open(filepath, 'r')
         buf = file_to_check.read(buf_size)
         while len(buf) > 0:
             hasher.update(buf)

--- a/jip/util.py
+++ b/jip/util.py
@@ -42,10 +42,10 @@ BUF_SIZE = 4096
 class DownloadException(Exception):
     pass
 
-def download(url, target, async=False, close_target=False, quiet=True):
+def download(url, target, non_blocking=False, close_target=False, quiet=True):
     import requests
     ### download file to target (target is a file-like object)
-    if async:
+    if non_blocking:
         pool.submit(url, target)
     else:
         try:


### PR DESCRIPTION
Fixes #48  https://devguide.python.org/devcycle/#end-of-life-branches

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

flake8 tests: https://travis-ci.org/jiptool/jip/jobs/534763857#L220