### PR TITLE
Original code do not handle the BOM, or the Byte Order Mark (http://e…

### DIFF
--- a/jip/maven.py
+++ b/jip/maven.py
@@ -110,7 +110,7 @@ class Pom(object):
             pom_string = re.sub(r"<project(.|\s)*?>", '<project>', self.pom_string, 1)
             parser = ElementTree.XMLParser(target=WhitespaceNormalizer())
             # Remove BOM, or a Byte Order Mark.  http://en.wikipedia.org/wiki/Byte_order_mark
-            if pom_string.startswith(codecs.BOM_UTF8):
+            if pom_string.startswith("ï»¿"):
                 pom_string = pom_string.replace("ï»¿", "")
             parser.feed(pom_string.encode('utf-8'))
             self.eletree = parser.close()

--- a/jip/maven.py
+++ b/jip/maven.py
@@ -19,8 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-
-
+import codecs
 import os
 import sys
 import re
@@ -111,7 +110,7 @@ class Pom(object):
             pom_string = re.sub(r"<project(.|\s)*?>", '<project>', self.pom_string, 1)
             parser = ElementTree.XMLParser(target=WhitespaceNormalizer())
             # Remove BOM, or a Byte Order Mark.  http://en.wikipedia.org/wiki/Byte_order_mark
-            if pom_string.startswith("ï»¿"):
+            if pom_string.startswith(codecs.BOM_UTF8):
                 pom_string = pom_string.replace("ï»¿", "")
             parser.feed(pom_string.encode('utf-8'))
             self.eletree = parser.close()

--- a/jip/maven.py
+++ b/jip/maven.py
@@ -110,6 +110,9 @@ class Pom(object):
             ## we use this dirty method to remove namesapce attribute so that elementtree will use default empty namespace
             pom_string = re.sub(r"<project(.|\s)*?>", '<project>', self.pom_string, 1)
             parser = ElementTree.XMLParser(target=WhitespaceNormalizer())
+            # Remove BOM, or a Byte Order Mark.  http://en.wikipedia.org/wiki/Byte_order_mark
+            if pom_string.startswith("ï»¿"):
+                pom_string = pom_string.replace("ï»¿", "")
             parser.feed(pom_string.encode('utf-8'))
             self.eletree = parser.close()
         return self.eletree

--- a/jip/maven.py
+++ b/jip/maven.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env jython
+# -
 # Copyright (C) 2011 Sun Ning<classicning@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -110,8 +111,8 @@ class Pom(object):
             pom_string = re.sub(r"<project(.|\s)*?>", '<project>', self.pom_string, 1)
             parser = ElementTree.XMLParser(target=WhitespaceNormalizer())
             # Remove BOM, or a Byte Order Mark.  http://en.wikipedia.org/wiki/Byte_order_mark
-            if pom_string.startswith("ï»¿"):
-                pom_string = pom_string.replace("ï»¿", "")
+            first_tag_position = pom_string.encode().decode('utf-8').find('<')
+            pom_string = pom_string[first_tag_position:]
             parser.feed(pom_string.encode('utf-8'))
             self.eletree = parser.close()
         return self.eletree


### PR DESCRIPTION
Adding a fix to remove the BOM, the Byte Order Mark (http://en.wikipedia.org/wiki/Byte_order_mark) causing parsing errors.
Example pom file with BOM is https://repo1.maven.org/maven2/dk/brics/automaton/automaton/1.11-8/automaton-1.11-8.pom