### PR TITLE
Enable console color coding on Windows

### DIFF
--- a/jip/main.py
+++ b/jip/main.py
@@ -20,14 +20,16 @@
 # SOFTWARE.
 #
 
-
+import os
 import sys
 import argparse
 
 from jip import logger
 from jip.commands import commands
 
+
 def main():
+    os.system("color")
     logger.debug("sys args %s" % sys.argv)
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")

--- a/jip/main.py
+++ b/jip/main.py
@@ -21,6 +21,7 @@
 #
 
 import os
+import platform
 import sys
 import argparse
 
@@ -29,7 +30,8 @@ from jip.commands import commands
 
 
 def main():
-    os.system("color")
+    if platform.system() == "Windows" and os.getenv("COMSPEC").find("cmd.exe") >= 0:
+        os.system("color")
     logger.debug("sys args %s" % sys.argv)
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")


### PR DESCRIPTION
This cleans up the output on Windows so that the escape codes are interpreted instead of printed raw.